### PR TITLE
Added Generic Programming

### DIFF
--- a/Assignment-1/Percolation/PercolationStat.hpp
+++ b/Assignment-1/Percolation/PercolationStat.hpp
@@ -3,35 +3,24 @@
 #include <fstream>
 #include <cmath>
 #include <vector>
-#include <stdexcept>
 #include "Percolation_WQU.hpp"
 #include "Percolation_QF.hpp"
-
+template <typename PercolationType>
 class PercolationStats {
     std::vector<double> thresholds;
     double cachedMean;
+    PercolationType p;   // same object reused
 
 public:
-    // perform independent trials on an n-by-n grid
-    PercolationStats(int n, int trials, const std::string &type) : cachedMean(0.0) {
+    PercolationStats(int n, int trials) 
+        : cachedMean(0.0), p(n) {  
         if (n <= 0 || trials <= 0) {
             throw std::invalid_argument("n and trials must be > 0");
         }
 
         thresholds.reserve(trials);
         for (int i = 0; i < trials; i++) {
-            int openCount = 0;
-
-            if (type == "QF") {
-                Percolation_QF p(n);
-                openCount = p.test();
-            } else if (type == "WQU") {
-                Percolation_WQU p(n);
-                openCount = p.test();
-            } else {
-                throw std::invalid_argument("Unknown percolation type: " + type);
-            }
-
+            int openCount = p.test();  
             double threshold = static_cast<double>(openCount) / (n * n);
             thresholds.push_back(threshold);
         }
@@ -62,7 +51,9 @@ public:
         return mean() + 1.96 * (s / std::sqrt(thresholds.size()));
     }
 
-    void report(std::ostream &out, const std::string &label) {
+    // Write results to file instead of cout
+    template <typename Stream>
+    void report(Stream &out, const std::string &label) {
         out << "=== " << label << " ===\n";
         out << "mean                    = " << mean() << '\n';
         out << "stddev                  = " << stddev() << '\n';

--- a/Assignment-1/Percolation/Percolation_QF.hpp
+++ b/Assignment-1/Percolation/Percolation_QF.hpp
@@ -10,11 +10,10 @@ class Percolation_QF {
     int n;                                // grid size (n x n)
     int openSites;                        // count of open sites
     std::vector<std::vector<bool>> open;  // track open sites
-    QuickFindUF uf;                     // union–find for connectivity
+    QuickFindUF uf;                       // union–find for connectivity
     int virtualTop;                       // virtual top node index
     int virtualBottom;                    // virtual bottom node index
 
-    // flatten (row,col) into 1D index
     int index(int row, int col) const {
         return row * n + col;
     }
@@ -24,6 +23,13 @@ class Percolation_QF {
     }
 
 public:
+    // default constructor (chooses n = 2 as example)
+    Percolation_QF() : n(2), openSites(0), open(2, std::vector<bool>(2, false)), uf(2+2) {
+        int totalSites = n * n;
+        virtualTop = totalSites;
+        virtualBottom = totalSites + 1;
+    }
+
     // creates n-by-n grid, with all sites initially blocked
     Percolation_QF(int n) : n(n), openSites(0), open(n, std::vector<bool>(n, false)), uf(n+2) {
         if (n <= 0) throw std::invalid_argument("Grid size must be > 0");
@@ -32,13 +38,11 @@ public:
         virtualBottom = totalSites + 1;
     }
 
-    // is the site (row, col) open?
     bool isOpen(int row, int col) {
         if (!valid(row, col)) throw std::invalid_argument("Invalid index");
         return open[row][col];
     }
 
-    // opens the site (row, col) if it is not open already
     void openSite(int row, int col) {
         if (!valid(row, col)) throw std::invalid_argument("Invalid index");
         if (open[row][col]) return;
@@ -46,13 +50,7 @@ public:
         open[row][col] = true;
         openSites++;
 
-        int site = index(row, col);
-
-        // connect to virtual top/bottom if in first or last row
-        if (row == 0) uf.unify({row,col}, {0,0}, n); // connect top row to virtualTop
-        if (row == n-1) uf.unify({row,col}, {n-1,0}, n); // connect bottom row to virtualBottom
-
-        // check neighbors
+        // connect to neighbors
         const int dr[4] = {-1, 1, 0, 0};
         const int dc[4] = {0, 0, -1, 1};
         for (int k = 0; k < 4; k++) {
@@ -63,13 +61,9 @@ public:
         }
     }
 
-    // is the site (row, col) full? (connected to top)
     bool isFull(int row, int col) {
         if (!valid(row, col)) throw std::invalid_argument("Invalid index");
         if (!isOpen(row, col)) return false;
-
-        int site = index(row, col);
-        // check connectivity to any open site in top row
         for (int j = 0; j < n; j++) {
             if (isOpen(0, j) && uf.find({row,col}, n) == uf.find({0,j}, n)) {
                 return true;
@@ -78,12 +72,10 @@ public:
         return false;
     }
 
-    // returns the number of open sites
     int numberOfOpenSites() {
         return openSites;
     }
 
-    // does the system percolate?
     bool percolates() {
         for (int j = 0; j < n; j++) {
             if (isOpen(0, j)) {
@@ -99,14 +91,12 @@ public:
         return false;
     }
 
-    // Monte Carlo test
     int test() {
         srand(time(0));
         Percolation_QF p(n);
-        int x, y;
         while (!p.percolates()) {
-            x = rand() % n;
-            y = rand() % n;
+            int x = rand() % n;
+            int y = rand() % n;
             p.openSite(x, y);
         }
         return p.numberOfOpenSites();


### PR DESCRIPTION
This implementation of the percolation system uses generic programming in PercolationStats.hpp to flexibly decide which Union-Find variant to use. because of  this, I added default constructors to the percolation implementations and made PercolationType a private member of the stats class, initializing it within the constructor. This way, a fresh percolation object is created for each trial, keeping the statistics logic decoupled from the specific Union-Find choice. In hindsight, this is something I should have already been doing, since it allows Quick Find, Weighted Quick Union, or any other variant to be swapped in without changing the PercolationStats code.